### PR TITLE
feat: Add support for Copier, Mover, Appender, Direr

### DIFF
--- a/generated.go
+++ b/generated.go
@@ -85,6 +85,10 @@ var pairMap = map[string]string{
 	"work_dir":            "string",
 }
 var (
+	_ Appender = &Storage{}
+	_ Copier   = &Storage{}
+	_ Direr    = &Storage{}
+	_ Mover    = &Storage{}
 	_ Storager = &Storage{}
 )
 
@@ -117,13 +121,65 @@ func parsePairStorageNew(opts []Pair) (pairStorageNew, error) {
 
 // DefaultStoragePairs is default pairs for specific action
 type DefaultStoragePairs struct {
-	Create   []Pair
-	Delete   []Pair
-	List     []Pair
-	Metadata []Pair
-	Read     []Pair
-	Stat     []Pair
-	Write    []Pair
+	CommitAppend []Pair
+	Copy         []Pair
+	Create       []Pair
+	CreateAppend []Pair
+	CreateDir    []Pair
+	Delete       []Pair
+	List         []Pair
+	Metadata     []Pair
+	Move         []Pair
+	Read         []Pair
+	Stat         []Pair
+	Write        []Pair
+	WriteAppend  []Pair
+}
+
+// pairStorageCommitAppend is the parsed struct
+type pairStorageCommitAppend struct {
+	pairs []Pair
+}
+
+// parsePairStorageCommitAppend will parse Pair slice into *pairStorageCommitAppend
+func (s *Storage) parsePairStorageCommitAppend(opts []Pair) (pairStorageCommitAppend, error) {
+	result := pairStorageCommitAppend{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageCommitAppend{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
+}
+
+// pairStorageCopy is the parsed struct
+type pairStorageCopy struct {
+	pairs []Pair
+}
+
+// parsePairStorageCopy will parse Pair slice into *pairStorageCopy
+func (s *Storage) parsePairStorageCopy(opts []Pair) (pairStorageCopy, error) {
+	result := pairStorageCopy{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageCopy{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
 }
 
 // pairStorageCreate is the parsed struct
@@ -150,6 +206,52 @@ func (s *Storage) parsePairStorageCreate(opts []Pair) (pairStorageCreate, error)
 			continue
 		default:
 			return pairStorageCreate{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
+}
+
+// pairStorageCreateAppend is the parsed struct
+type pairStorageCreateAppend struct {
+	pairs []Pair
+}
+
+// parsePairStorageCreateAppend will parse Pair slice into *pairStorageCreateAppend
+func (s *Storage) parsePairStorageCreateAppend(opts []Pair) (pairStorageCreateAppend, error) {
+	result := pairStorageCreateAppend{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageCreateAppend{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
+}
+
+// pairStorageCreateDir is the parsed struct
+type pairStorageCreateDir struct {
+	pairs []Pair
+}
+
+// parsePairStorageCreateDir will parse Pair slice into *pairStorageCreateDir
+func (s *Storage) parsePairStorageCreateDir(opts []Pair) (pairStorageCreateDir, error) {
+	result := pairStorageCreateDir{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageCreateDir{}, services.PairUnsupportedError{Pair: v}
 		}
 	}
 
@@ -237,6 +339,29 @@ func (s *Storage) parsePairStorageMetadata(opts []Pair) (pairStorageMetadata, er
 		switch v.Key {
 		default:
 			return pairStorageMetadata{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
+}
+
+// pairStorageMove is the parsed struct
+type pairStorageMove struct {
+	pairs []Pair
+}
+
+// parsePairStorageMove will parse Pair slice into *pairStorageMove
+func (s *Storage) parsePairStorageMove(opts []Pair) (pairStorageMove, error) {
+	result := pairStorageMove{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageMove{}, services.PairUnsupportedError{Pair: v}
 		}
 	}
 
@@ -377,6 +502,105 @@ func (s *Storage) parsePairStorageWrite(opts []Pair) (pairStorageWrite, error) {
 	return result, nil
 }
 
+// pairStorageWriteAppend is the parsed struct
+type pairStorageWriteAppend struct {
+	pairs []Pair
+}
+
+// parsePairStorageWriteAppend will parse Pair slice into *pairStorageWriteAppend
+func (s *Storage) parsePairStorageWriteAppend(opts []Pair) (pairStorageWriteAppend, error) {
+	result := pairStorageWriteAppend{
+		pairs: opts,
+	}
+
+	for _, v := range opts {
+		switch v.Key {
+		default:
+			return pairStorageWriteAppend{}, services.PairUnsupportedError{Pair: v}
+		}
+	}
+
+	// Check required pairs.
+
+	return result, nil
+}
+
+// CommitAppend will commit and finish an append process.
+//
+// This function will create a context by default.
+func (s *Storage) CommitAppend(o *Object, pairs ...Pair) (err error) {
+	ctx := context.Background()
+	return s.CommitAppendWithContext(ctx, o, pairs...)
+}
+
+// CommitAppendWithContext will commit and finish an append process.
+func (s *Storage) CommitAppendWithContext(ctx context.Context, o *Object, pairs ...Pair) (err error) {
+	defer func() {
+		err = s.formatError("commit_append", err)
+	}()
+	if !o.Mode.IsAppend() {
+		err = services.ObjectModeInvalidError{Expected: ModeAppend, Actual: o.Mode}
+		return
+	}
+
+	pairs = append(pairs, s.defaultPairs.CommitAppend...)
+	var opt pairStorageCommitAppend
+
+	opt, err = s.parsePairStorageCommitAppend(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.commitAppend(ctx, o, opt)
+}
+
+// Copy will copy an Object or multiple object in the service.
+//
+// ## Behavior
+//
+// - Copy only copy one and only one object.
+//   - Service DON'T NEED to support copy a non-empty directory or copy files recursively.
+//   - User NEED to implement copy a non-empty directory and copy recursively by themself.
+//   - Copy a file to a directory SHOULD return `ErrObjectModeInvalid`.
+// - Copy SHOULD NOT return an error as dst object exists.
+//   - Service that has native support for `overwrite` doesn't NEED to check the dst object exists or not.
+//   - Service that doesn't have native support for `overwrite` SHOULD check and delete the dst object if exists.
+// - A successful copy opration should be complete, which means the dst object's content and metadata should be the same as src object.
+//
+// This function will create a context by default.
+func (s *Storage) Copy(src string, dst string, pairs ...Pair) (err error) {
+	ctx := context.Background()
+	return s.CopyWithContext(ctx, src, dst, pairs...)
+}
+
+// CopyWithContext will copy an Object or multiple object in the service.
+//
+// ## Behavior
+//
+// - Copy only copy one and only one object.
+//   - Service DON'T NEED to support copy a non-empty directory or copy files recursively.
+//   - User NEED to implement copy a non-empty directory and copy recursively by themself.
+//   - Copy a file to a directory SHOULD return `ErrObjectModeInvalid`.
+// - Copy SHOULD NOT return an error as dst object exists.
+//   - Service that has native support for `overwrite` doesn't NEED to check the dst object exists or not.
+//   - Service that doesn't have native support for `overwrite` SHOULD check and delete the dst object if exists.
+// - A successful copy opration should be complete, which means the dst object's content and metadata should be the same as src object.
+func (s *Storage) CopyWithContext(ctx context.Context, src string, dst string, pairs ...Pair) (err error) {
+	defer func() {
+		err = s.formatError("copy", err, src, dst)
+	}()
+
+	pairs = append(pairs, s.defaultPairs.Copy...)
+	var opt pairStorageCopy
+
+	opt, err = s.parsePairStorageCopy(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.copy(ctx, src, dst, opt)
+}
+
 // Create will create a new object without any api call.
 //
 // ## Behavior
@@ -393,6 +617,68 @@ func (s *Storage) Create(path string, pairs ...Pair) (o *Object) {
 	opt, _ = s.parsePairStorageCreate(pairs)
 
 	return s.create(path, opt)
+}
+
+// CreateAppend will create an append object.
+//
+// ## Behavior
+//
+// - CreateAppend SHOULD create an appendable object with position 0 and size 0.
+// - CreateAppend SHOULD NOT return an error as the object exist.
+//   - Service SHOULD check and delete the object if exists.
+//
+// This function will create a context by default.
+func (s *Storage) CreateAppend(path string, pairs ...Pair) (o *Object, err error) {
+	ctx := context.Background()
+	return s.CreateAppendWithContext(ctx, path, pairs...)
+}
+
+// CreateAppendWithContext will create an append object.
+//
+// ## Behavior
+//
+// - CreateAppend SHOULD create an appendable object with position 0 and size 0.
+// - CreateAppend SHOULD NOT return an error as the object exist.
+//   - Service SHOULD check and delete the object if exists.
+func (s *Storage) CreateAppendWithContext(ctx context.Context, path string, pairs ...Pair) (o *Object, err error) {
+	defer func() {
+		err = s.formatError("create_append", err, path)
+	}()
+
+	pairs = append(pairs, s.defaultPairs.CreateAppend...)
+	var opt pairStorageCreateAppend
+
+	opt, err = s.parsePairStorageCreateAppend(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.createAppend(ctx, path, opt)
+}
+
+// CreateDir will create a new dir object.
+//
+// This function will create a context by default.
+func (s *Storage) CreateDir(path string, pairs ...Pair) (o *Object, err error) {
+	ctx := context.Background()
+	return s.CreateDirWithContext(ctx, path, pairs...)
+}
+
+// CreateDirWithContext will create a new dir object.
+func (s *Storage) CreateDirWithContext(ctx context.Context, path string, pairs ...Pair) (o *Object, err error) {
+	defer func() {
+		err = s.formatError("create_dir", err, path)
+	}()
+
+	pairs = append(pairs, s.defaultPairs.CreateDir...)
+	var opt pairStorageCreateDir
+
+	opt, err = s.parsePairStorageCreateDir(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.createDir(ctx, path, opt)
 }
 
 // Delete will delete an object from service.
@@ -488,6 +774,53 @@ func (s *Storage) Metadata(pairs ...Pair) (meta *StorageMeta) {
 	opt, _ = s.parsePairStorageMetadata(pairs)
 
 	return s.metadata(opt)
+}
+
+// Move will move an object in the service.
+//
+// ## Behavior
+//
+// - Move only move one and only one object.
+//   - Service DON'T NEED to support move a non-empty directory.
+//   - User NEED to implement move a non-empty directory by themself.
+//   - Move a file to a directory SHOULD return `ErrObjectModeInvalid`.
+// - Move SHOULD NOT return an error as dst object exists.
+//   - Service that has native support for `overwrite` doesn't NEED to check the dst object exists or not.
+//   - Service that doesn't have native support for `overwrite` SHOULD check and delete the dst object if exists.
+// - A successful move operation SHOULD be complete, which means the dst object's content and metadata should be the same as src object.
+//
+// This function will create a context by default.
+func (s *Storage) Move(src string, dst string, pairs ...Pair) (err error) {
+	ctx := context.Background()
+	return s.MoveWithContext(ctx, src, dst, pairs...)
+}
+
+// MoveWithContext will move an object in the service.
+//
+// ## Behavior
+//
+// - Move only move one and only one object.
+//   - Service DON'T NEED to support move a non-empty directory.
+//   - User NEED to implement move a non-empty directory by themself.
+//   - Move a file to a directory SHOULD return `ErrObjectModeInvalid`.
+// - Move SHOULD NOT return an error as dst object exists.
+//   - Service that has native support for `overwrite` doesn't NEED to check the dst object exists or not.
+//   - Service that doesn't have native support for `overwrite` SHOULD check and delete the dst object if exists.
+// - A successful move operation SHOULD be complete, which means the dst object's content and metadata should be the same as src object.
+func (s *Storage) MoveWithContext(ctx context.Context, src string, dst string, pairs ...Pair) (err error) {
+	defer func() {
+		err = s.formatError("move", err, src, dst)
+	}()
+
+	pairs = append(pairs, s.defaultPairs.Move...)
+	var opt pairStorageMove
+
+	opt, err = s.parsePairStorageMove(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.move(ctx, src, dst, opt)
 }
 
 // Read will read the file's data.
@@ -589,6 +922,35 @@ func (s *Storage) WriteWithContext(ctx context.Context, path string, r io.Reader
 	}
 
 	return s.write(ctx, path, r, size, opt)
+}
+
+// WriteAppend will append content to an append object.
+//
+// This function will create a context by default.
+func (s *Storage) WriteAppend(o *Object, r io.Reader, size int64, pairs ...Pair) (n int64, err error) {
+	ctx := context.Background()
+	return s.WriteAppendWithContext(ctx, o, r, size, pairs...)
+}
+
+// WriteAppendWithContext will append content to an append object.
+func (s *Storage) WriteAppendWithContext(ctx context.Context, o *Object, r io.Reader, size int64, pairs ...Pair) (n int64, err error) {
+	defer func() {
+		err = s.formatError("write_append", err)
+	}()
+	if !o.Mode.IsAppend() {
+		err = services.ObjectModeInvalidError{Expected: ModeAppend, Actual: o.Mode}
+		return
+	}
+
+	pairs = append(pairs, s.defaultPairs.WriteAppend...)
+	var opt pairStorageWriteAppend
+
+	opt, err = s.parsePairStorageWriteAppend(pairs)
+	if err != nil {
+		return
+	}
+
+	return s.writeAppend(ctx, o, r, size, opt)
 }
 
 func init() {

--- a/object.go
+++ b/object.go
@@ -81,7 +81,17 @@ func (o *object) insertChildByPath(path string) *object {
 	ps := strings.Split(path, "/")
 	last := len(ps) - 1
 
-	for _, v := range ps[:last] {
+	p = o.makeDirAll(ps[:last])
+	if p == nil {
+		return nil
+	}
+
+	return p.insertChild(ps[last], newObject(p, types.ModeRead))
+}
+
+func (o *object) makeDirAll(ps []string) *object {
+	p := o
+	for _, v := range ps {
 		if v == "" {
 			continue
 		}
@@ -97,5 +107,5 @@ func (o *object) insertChildByPath(path string) *object {
 
 		p = ro
 	}
-	return p.insertChild(ps[last], newObject(p, types.ModeRead))
+	return p
 }

--- a/service.toml
+++ b/service.toml
@@ -1,6 +1,7 @@
 name = "memory"
 
 [namespace.storage]
+implement = ["copier", "mover", "appender", "direr"]
 
 [namespace.storage.op.create]
 optional = ["object_mode"]

--- a/storage.go
+++ b/storage.go
@@ -5,13 +5,76 @@ import (
 	"github.com/beyondstorage/go-storage/v4/services"
 	. "github.com/beyondstorage/go-storage/v4/types"
 	"io"
+	"strings"
 )
+
+func (s *Storage) commitAppend(ctx context.Context, o *Object, opt pairStorageCommitAppend) (err error) {
+	return
+}
+
+func (s *Storage) copy(ctx context.Context, src string, dst string, opt pairStorageCopy) (err error) {
+	rs := s.absPath(src)
+	rd := s.absPath(dst)
+
+	_, ro := s.root.getChildByPath(rs)
+	if ro == nil {
+		return services.ErrObjectNotExist
+	}
+
+	_, r := s.root.getChildByPath(rd)
+	if r != nil && r.mode.IsDir() {
+		return services.ErrObjectModeInvalid
+	}
+
+	o := s.root.insertChildByPath(rd)
+	if o == nil {
+		return services.ErrObjectModeInvalid
+	}
+
+	o.length = ro.length
+	o.mode = ro.mode
+
+	o.data = make([]byte, ro.length)
+	copy(o.data, ro.data)
+	return nil
+}
 
 func (s *Storage) create(path string, opt pairStorageCreate) (o *Object) {
 	o = NewObject(s, true)
 	o.ID = s.absPath(path)
 	o.Path = s.relPath(path)
+	if opt.HasObjectMode && opt.ObjectMode.IsDir() {
+		o.Mode = ModeDir
+	}
 	return o
+}
+
+func (s *Storage) createAppend(ctx context.Context, path string, opt pairStorageCreateAppend) (o *Object, err error) {
+	child := s.root.insertChildByPath(s.absPath(path))
+	if child == nil {
+		return nil, services.ErrObjectModeInvalid
+	}
+	child.mode = ModeRead | ModeAppend
+
+	o = NewObject(s, true)
+	o.ID = s.absPath(path)
+	o.Path = s.relPath(path)
+	o.Mode = ModeRead | ModeAppend
+	o.SetAppendOffset(0)
+
+	return o, nil
+}
+
+func (s *Storage) createDir(ctx context.Context, path string, opt pairStorageCreateDir) (o *Object, err error) {
+	if s.root.makeDirAll(strings.Split(s.absPath(path), "/")) == nil {
+		return nil, services.ErrObjectModeInvalid
+	}
+
+	o = NewObject(s, true)
+	o.ID = s.absPath(path)
+	o.Path = s.relPath(path)
+	o.Mode |= ModeDir
+	return o, nil
 }
 
 func (s *Storage) delete(ctx context.Context, path string, opt pairStorageDelete) (err error) {
@@ -59,13 +122,38 @@ func (s *Storage) metadata(opt pairStorageMetadata) (meta *StorageMeta) {
 	}
 }
 
+func (s *Storage) move(ctx context.Context, src string, dst string, opt pairStorageMove) (err error) {
+	rs := s.absPath(src)
+	rd := s.absPath(dst)
+
+	names, rso := s.root.getChildByPath(rs)
+	if rso == nil {
+		return services.ErrObjectNotExist
+	}
+
+	_, rdo := s.root.getChildByPath(rd)
+	if rdo != nil && rdo.mode.IsDir() {
+		return services.ErrObjectModeInvalid
+	}
+
+	ps := strings.Split(dst, "/")
+	rso.parent.removeChild(names)
+	rso.parent.insertChild(ps[len(ps)-1], rso)
+	return
+}
+
 func (s *Storage) read(ctx context.Context, path string, w io.Writer, opt pairStorageRead) (n int64, err error) {
 	name, o := s.root.getChildByPath(s.absPath(path))
 	if name == "" {
 		return 0, services.ErrObjectNotExist
 	}
 
-	written, err := w.Write(o.data)
+	offset := int64(0)
+	if opt.HasOffset {
+		offset = opt.Offset
+	}
+
+	written, err := w.Write(o.data[offset:])
 	if err != nil {
 		return int64(written), err
 	}
@@ -101,5 +189,23 @@ func (s *Storage) write(ctx context.Context, path string, r io.Reader, size int6
 		return int64(read), nil
 	}
 
+	return int64(read), nil
+}
+
+func (s *Storage) writeAppend(ctx context.Context, o *Object, r io.Reader, size int64, opt pairStorageWriteAppend) (n int64, err error) {
+	_, ro := s.root.getChildByPath(o.ID)
+	if ro == nil {
+		ro = s.root.insertChildByPath(o.ID)
+		if ro == nil {
+			return 0, services.ErrObjectModeInvalid
+		}
+	}
+	buf := make([]byte, size)
+	read, err := r.Read(buf)
+	ro.data = append(ro.data, buf[:read]...)
+	ro.length += int64(read)
+	if err != nil {
+		return int64(read), nil
+	}
 	return int64(read), nil
 }

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -9,3 +9,19 @@ import (
 func TestStorage(t *testing.T) {
 	tests.TestStorager(t, setupTest(t))
 }
+
+func TestAppend(t *testing.T) {
+	tests.TestAppender(t, setupTest(t))
+}
+
+func TestDir(t *testing.T) {
+	tests.TestDirer(t, setupTest(t))
+}
+
+func TestCopy(t *testing.T) {
+	tests.TestCopier(t, setupTest(t))
+}
+
+func TestMove(t *testing.T) {
+	tests.TestMover(t, setupTest(t))
+}

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,10 @@ type Storage struct {
 	root    *object
 
 	types.UnimplementedStorager
+	types.UnimplementedAppender
+	types.UnimplementedCopier
+	types.UnimplementedDirer
+	types.UnimplementedMover
 }
 
 // String implements Storager.String


### PR DESCRIPTION
make `go-service-memory` support `copier`, `mover`, `appender`, `direr`. 
the integration-test has been passed